### PR TITLE
IMAGING-308 Fix to unit test for windows

### DIFF
--- a/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/jpeg/iptc/IptcParserTest.java
@@ -101,6 +101,7 @@ public class IptcParserTest {
         List<GenericImageMetadataItem> items = (List<GenericImageMetadataItem>) photoshopMetadata.getItems();
         GenericImageMetadataItem thanksInMandarin = items.get(3);
         // converted the thank-you in chinese characters to unicode for comparison here
-        assertArrayEquals("\u8c22\u8c22".getBytes(StandardCharsets.UTF_8), thanksInMandarin.getText().getBytes());
+        assertArrayEquals("\u8c22\u8c22".getBytes(StandardCharsets.UTF_8), 
+              thanksInMandarin.getText().getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
The unit test was failing under Windows due to a missing character encoding setting.  This change should ensure that the test runs under both Windows and Linux.